### PR TITLE
Updated to node 14 and moved the java install to use apt-get install

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -1,3 +1,3 @@
-FROM helixta/helixdev:2020-08-24
+FROM helixta/helixdev:2020-09-22
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/dodo.py
+++ b/docker/dodo.py
@@ -8,16 +8,13 @@ ROOT = Path('../..')
 helixdevimagebuilt = MarkerFile(HERE/'build/.helixdevimagebuilt')
 helixdevimagepushed = MarkerFile(HERE/'build/.helixdevimagepushed')
 
-jdktarfile = HOME/'archive/jdk-8u152-linux-x64.tar.gz'
-
 def task_docker_build_helixdev_image():
     context = DockerContext()
-    context.file( jdktarfile, jdktarfile.name)
     context.file( HERE/'install.helixdev.sh', 'install.sh')
     image = DockerImage( 'helixdev', context)
     image.cmd( 'FROM ubuntu:18.04' )
     image.cmd( 'MAINTAINER Helix Team <support@helixta.com.au>' )
-    image.cmd( 'COPY install.sh {} /tmp/'.format(jdktarfile.name) )
+    image.cmd( 'COPY install.sh /tmp/')
     image.cmd( 'RUN sh -x /tmp/install.sh && rm -r /tmp/*' )
 
     return {

--- a/docker/install.helixdev.sh
+++ b/docker/install.helixdev.sh
@@ -54,17 +54,6 @@ dpkg -i docker-ce_19.03.8~3-0~ubuntu-bionic_amd64.deb
 rm /tmp/*.deb
 curl -L "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
-# Unpack java 8, with specified minor version
-#MINOR=152
-#mkdir -p /opt/jdk
-#cd /opt/jdk
-#tar -zxf /tmp/jdk-8u$MINOR-linux-x64.tar.gz -C /opt/jdk
-#update-alternatives --install /usr/bin/java java /opt/jdk/jdk1.8.0_$MINOR/bin/java 100
-#update-alternatives --install /usr/bin/javac javac /opt/jdk/jdk1.8.0_$MINOR/bin/javac 100
-#update-alternatives --install /usr/bin/jstack jstack /opt/jdk/jdk1.8.0_$MINOR/bin/jstack 100
-#update-alternatives --install /usr/bin/javadoc javadoc /opt/jdk/jdk1.8.0_$MINOR/bin/javadoc 100
-#update-alternatives --install /usr/bin/jar jar /opt/jdk/jdk1.8.0_$MINOR/bin/jar 100
-
 # Install bazel from a binary release
 VERSION=2.1.1
 INSTALLER=bazel-$VERSION-installer-linux-x86_64.sh

--- a/docker/install.helixdev.sh
+++ b/docker/install.helixdev.sh
@@ -10,7 +10,7 @@ apt-get update
 apt-get install -y curl apt-transport-https gnupg2
 
 # Install yarn, node, etc
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
+curl -sL https://deb.nodesource.com/setup_14.x | bash -
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 apt-get update && apt-get -y install nodejs yarn
@@ -36,7 +36,8 @@ apt-get install -y \
   python3-pip \
   python3-gdbm \
   awscli \
-  nginx
+  nginx \
+  openjdk-8-jdk
 
 # Install some python3 packages via pip
 pip3 install doit pystache
@@ -54,15 +55,15 @@ rm /tmp/*.deb
 curl -L "https://github.com/docker/compose/releases/download/1.25.4/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 
 # Unpack java 8, with specified minor version
-MINOR=152
-mkdir -p /opt/jdk
-cd /opt/jdk
-tar -zxf /tmp/jdk-8u$MINOR-linux-x64.tar.gz -C /opt/jdk
-update-alternatives --install /usr/bin/java java /opt/jdk/jdk1.8.0_$MINOR/bin/java 100
-update-alternatives --install /usr/bin/javac javac /opt/jdk/jdk1.8.0_$MINOR/bin/javac 100
-update-alternatives --install /usr/bin/jstack jstack /opt/jdk/jdk1.8.0_$MINOR/bin/jstack 100
-update-alternatives --install /usr/bin/javadoc javadoc /opt/jdk/jdk1.8.0_$MINOR/bin/javadoc 100
-update-alternatives --install /usr/bin/jar jar /opt/jdk/jdk1.8.0_$MINOR/bin/jar 100
+#MINOR=152
+#mkdir -p /opt/jdk
+#cd /opt/jdk
+#tar -zxf /tmp/jdk-8u$MINOR-linux-x64.tar.gz -C /opt/jdk
+#update-alternatives --install /usr/bin/java java /opt/jdk/jdk1.8.0_$MINOR/bin/java 100
+#update-alternatives --install /usr/bin/javac javac /opt/jdk/jdk1.8.0_$MINOR/bin/javac 100
+#update-alternatives --install /usr/bin/jstack jstack /opt/jdk/jdk1.8.0_$MINOR/bin/jstack 100
+#update-alternatives --install /usr/bin/javadoc javadoc /opt/jdk/jdk1.8.0_$MINOR/bin/javadoc 100
+#update-alternatives --install /usr/bin/jar jar /opt/jdk/jdk1.8.0_$MINOR/bin/jar 100
 
 # Install bazel from a binary release
 VERSION=2.1.1


### PR DESCRIPTION
Updated to the latest node 14.
Moved to installing java with apt-get instead of relying on a hard coded downloaded tar.gz of the jdk.