### PR TITLE
Trigger a rebuild to workaround sdkman self-updating.

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -1,3 +1,3 @@
-FROM helixta/helixdev:2021-06-23
+FROM helixta/helixdev:2021-07-13
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/03-install-bazelisk-sdkman.sh
+++ b/docker/03-install-bazelisk-sdkman.sh
@@ -22,6 +22,7 @@ cat << EOF > ${SDKMAN_DIR}/etc/config
 # https://sdkman.io/usage#config
 
 # make sdkman non-interactive, preferred for CI environments
+# (buggy: Replace after sdkman > 5.11.7 is released)
 sdkman_auto_answer=true
 
 # perform automatic selfupdates?


### PR DESCRIPTION
Fix would be to disable self-updating.
But it was buggy in sdkman.

The fix in sdkman is landed in https://github.com/sdkman/sdkman-cli/commit/e557c9a22a805e9ead9c01977c1ee6b4ac507540
but not yet released in https://github.com/sdkman/sdkman-cli/releases/tag/5.11.7